### PR TITLE
Update framework/XEH_postInit.sqf

### DIFF
--- a/framework/XEH_postInit.sqf
+++ b/framework/XEH_postInit.sqf
@@ -35,7 +35,7 @@ enableSaving [false,false];
 //UNCONSCIOUS EH
 ["ace_unconscious", {
     params [["_unit", objNull],["_state", false]];
-    if (ace_medical_enableUnconsciousnessAI == 0 || {!_state || {!(local _unit)}}) exitWith {};
+    if (ace_medical_enableUnconsciousnessAI == 0 || {!_state || {!(local _unit) || {var_enemySide != (side _unit) }}}) exitWith {};
 
     if (isPlayer _unit) then {
         [{ace_player setUnitTrait ["camouflageCoef",var_camoCoef];}, [], 30] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
Following a convo with Garrus, I wanted to expand options for units waking up automatically. Specifically to create objectives that are not subject to waking randomly from unconciousness. This change seems to work for me by separating units based on faction against var_enemySide , is there a better way?

Co-Authored-By: G3rrus <g3rrus@users.noreply.github.com>